### PR TITLE
Fixed bug with MaxRetries, made MaxRetries changeable by user.

### DIFF
--- a/Certstream/Certstream.cs
+++ b/Certstream/Certstream.cs
@@ -33,7 +33,7 @@ namespace Certstream
         /// <summary>
         /// The maximum limit of consecutive reconnection fails until an exception is thrown.
         /// </summary>
-        private const int MaxRetries = 10;
+        private readonly int MaxRetries;
 
         private ClientWebSocket WS;
         private CancellationTokenSource Source;
@@ -60,9 +60,8 @@ namespace Certstream
             }
         }
 
-        public CertstreamClient()
-        {
-            
+        public CertstreamClient(int maxRetries=10) {
+            MaxRetries = maxRetries;
         }
 
         /// <summary>
@@ -112,7 +111,7 @@ namespace Certstream
             {
                 Debug.WriteLine($"Failed to connect to WebSocket: {ex.Message}");
 
-                if (Retries >= MaxRetries) throw new($"Failed to connect to Certstream {Retries} times.");
+                if (MaxRetries >= 0 && Retries >= MaxRetries) throw new($"Failed to connect to Certstream {Retries} times.");
 
                 await Task.Delay(ReconnectionDelay);
                 Connect();

--- a/Certstream/Certstream.cs
+++ b/Certstream/Certstream.cs
@@ -112,7 +112,7 @@ namespace Certstream
             {
                 Debug.WriteLine($"Failed to connect to WebSocket: {ex.Message}");
 
-                if (Retries <= MaxRetries) throw new($"Failed to connect to Certstream {Retries} times.");
+                if (Retries >= MaxRetries) throw new($"Failed to connect to Certstream {Retries} times.");
 
                 await Task.Delay(ReconnectionDelay);
                 Connect();


### PR DESCRIPTION
Changed `Retries <= MaxRetries` to `Retries >= MaxRetries`.
Added optional parameter for MaxRetries in the constructor of CertstreamClient.
If optional MaxRetries parameter is set to negative value, there is no limit to the number of retries.