### PR TITLE
Fixes #2

### DIFF
--- a/Certstream/Certstream.cs
+++ b/Certstream/Certstream.cs
@@ -89,6 +89,7 @@ namespace Certstream
         public async void Stop()
         {
             Running = false;
+            Pinger.Stop();
             await WS.CloseAsync(WebSocketCloseStatus.NormalClosure, "User demands a WebSocket closure.", Source.Token);
         }
 

--- a/Certstream/Certstream.cs
+++ b/Certstream/Certstream.cs
@@ -76,6 +76,10 @@ namespace Certstream
         {
             Running = true;
             Connect();
+            Pinger = new();
+            Pinger.Interval = PingInterval;
+            Pinger.Elapsed += async (o, e) => await Ping();
+            Pinger.Start();
             await Task.CompletedTask;
         }
 
@@ -99,11 +103,6 @@ namespace Certstream
             Source = new();
             WS = new();
             WS.Options.SetRequestHeader("User-Agent", UserAgent);
-
-            Pinger = new();
-            Pinger.Interval = PingInterval;
-            Pinger.Elapsed += async (o, e) => await Ping();
-            Pinger.Start();
 
             try
             {
@@ -154,9 +153,8 @@ namespace Certstream
         /// The method that sends a <c>ping</c> message into the WebSocket to prevent it from closing.
         /// </summary>
         /// <returns></returns>
-        public async Task Ping()
-        {
-            if (WS.State != WebSocketState.Open) Pinger.Stop();
+        public async Task Ping() {
+            if (WS.State != WebSocketState.Open) return;
 
             try
             {


### PR DESCRIPTION
This should fix the exception that occurs when the program is running for 8+ hours. The timer is initialized only once, when the client is started.